### PR TITLE
Activate a specific monitor using = in d

### DIFF
--- a/src/Manager.ahk
+++ b/src/Manager.ahk
@@ -134,7 +134,10 @@ Manager_activateMonitor(d)
         View_#%Manager_aMonitor%_#%aView%_aWndId := aWndId
     }
 
-    Manager_aMonitor := Manager_loop(Manager_aMonitor, d, 1, Manager_monitorCount)
+    if ( SubStr(d, 1, 1 ) == "=" )
+		  Manager_aMonitor := SubStr(d,2)
+	  else
+      Manager_aMonitor := Manager_loop(Manager_aMonitor, d, 1, Manager_monitorCount)
     v := Monitor_#%Manager_aMonitor%_aView_#1
     wndId := View_#%Manager_aMonitor%_#%v%_aWndId
     If Not (wndId And WinExist("ahk_id" wndId))
@@ -827,7 +830,10 @@ Manager_setWindowMonitor(d)
     If Config_dynamicTiling
       View_arrange(Manager_aMonitor, Monitor_#%Manager_aMonitor%_aView_#1)
 
-    Manager_aMonitor := Manager_loop(Manager_aMonitor, d, 1, Manager_monitorCount)
+    if ( SubStr(d, 1, 1 ) == "=" )
+		  Manager_aMonitor := SubStr(d,2)
+    else
+      Manager_aMonitor := Manager_loop(Manager_aMonitor, d, 1, Manager_monitorCount)
     Monitor_moveWindow(Manager_aMonitor, aWndId)
     v := Monitor_#%Manager_aMonitor%_aView_#1
     Manager_#%aWndId%_tags := 1 << v - 1


### PR DESCRIPTION
I wanted to be able to go to a specific monitor using a hotkey. If I'm already on that monitor, I don't want to move away. This change allows this by putting =\<n\> in the argument for the Manager_activateMonitor function. I've also made the change for Manager_setWindowMonitor just to be consistent.