### PR TITLE
Add Monitor_greedyView()

### DIFF
--- a/src/Manager.ahk
+++ b/src/Manager.ahk
@@ -932,6 +932,52 @@ Manager_setViewMonitor(i, d = 0) {
   }
 }
 
+Manager__stealView(m, v) {
+  Local om, match
+  
+  match := 0
+  
+  Loop, % Manager_monitorCount {
+    om := A_Index
+    if (Not (m = om)) And View_#%om%_#%v%_wndIds {
+      View_#%m%_#%v%_wndIds := View_#%om%_#%v%_wndIds View_#%m%_#%v%_wndIds
+      StringTrimRight, wndIds, View_#%om%_#%v%_wndIds, 1
+      Loop, PARSE, wndIds, `;
+      {
+        Loop, % Config_viewCount {
+          StringReplace, View_#%om%_#%A_Index%_wndIds, View_#%om%_#%A_Index%_wndIds, %A_LoopField%`;,
+          View_setActiveWindow(om, A_Index, 0)
+        }
+
+        Monitor_moveWindow(m, A_LoopField)
+        Window_#%A_LoopField%_tags := 1 << v - 1
+      }
+      View_#%m%_#%v%_layout_#1      := View_#%om%_#%v%_layout_#1
+      View_#%m%_#%v%_layout_#2      := View_#%om%_#%v%_layout_#2
+      View_#%m%_#%v%_layoutAxis_#1  := View_#%om%_#%v%_layoutAxis_#1
+      View_#%m%_#%v%_layoutAxis_#2  := View_#%om%_#%v%_layoutAxis_#2
+      View_#%m%_#%v%_layoutAxis_#3  := View_#%om%_#%v%_layoutAxis_#3
+      View_#%m%_#%v%_layoutGapWidth := View_#%om%_#%v%_layoutGapWidth
+      View_#%m%_#%v%_layoutMFact    := View_#%om%_#%v%_layoutMFact
+      View_#%m%_#%v%_layoutMX       := View_#%om%_#%v%_layoutMX
+      View_#%m%_#%v%_layoutMY       := View_#%om%_#%v%_layoutMY
+      View_#%m%_#%v%_layoutSymbol   := View_#%om%_#%v%_layoutSymbol
+      View_#%m%_#%v%_margins        := View_#%om%_#%v%_margins
+      View_#%m%_#%v%_showStackArea  := View_#%om%_#%v%_showStackArea
+
+      If (Monitor_#%om%_aView_#1 = v) {
+        View_arrange(om, v)
+        match := om
+      }
+      Loop, % Config_viewCount {
+        Bar_updateView(om, v)
+      }
+    }
+  }
+
+  Return match
+}
+
 Manager_setWindowBorders()
 {
   Local ncm, ncmSize

--- a/src/Monitor.ahk
+++ b/src/Monitor.ahk
@@ -32,8 +32,89 @@ Monitor_init(m, doRestore) {
   Bar_init(m)
 }
 
+Monitor__hideView(m) {
+  Local aView, wndIds
+  
+  aView := Monitor_#%m%_aView_#1
+  
+  SetWinDelay, 0
+  StringTrimRight, wndIds, View_#%m%_#%aView%_wndIds, 1
+  Loop, PARSE, wndIds, `;
+  {
+    If Not (Window_#%A_LoopField%_tags & (1 << i - 1))
+      Window_hide(A_LoopField)
+  }
+  SetWinDelay, 10
+}
+
+Monitor__showView(m, v) {
+  Local aView, detectHidden, wndId, wndIds
+  
+  aView := Monitor_#%m%_aView_#1
+  Monitor_#%m%_aView_#2 := aView
+  Monitor_#%m%_aView_#1 := v
+
+  detectHidden := A_DetectHiddenWindows
+  DetectHiddenWindows, On
+  wndId := View_getActiveWindow(m, v)
+  If wndId
+    Window_set(wndId, "AlwaysOnTop", "On")
+  View_arrange(m, v)
+  DetectHiddenWindows, %detectHidden%
+  StringTrimRight, wndIds, View_#%m%_#%v%_wndIds, 1
+  SetWinDelay, 0
+  Loop, PARSE, wndIds, `;
+  {
+    Window_show(A_LoopField)
+  }
+  Window_set(wndId, "AlwaysOnTop", "Off")
+  SetWinDelay, 10
+
+  Bar_updateView(m, aView)
+  Bar_updateView(m, v)
+}
+
+Monitor_greedyView(i, d = 0) {
+  Local aView, aWndId, m, n, wndId, om
+
+  If (i = -1)
+    i := Monitor_#%Manager_aMonitor%_aView_#2
+  Else If (i = 0)
+    i := Monitor_#%Manager_aMonitor%_aView_#1
+  i := Manager_loop(i, d, 1, Config_viewCount)
+
+  Debug_logMessage("DEBUG[1] Monitor_greedyView; i: " . i . ", d: " . d . ", Manager_aMonitor: " . Manager_aMonitor . ", wndIds: " . View_#%Manager_aMonitor%_#%i%_wndIds, 1)
+  If (i <= 0) Or (i > Config_viewCount) Or Manager_hideShow
+    Return
+  ;; Re-arrange the windows on the active view.
+  If (i = Monitor_#%Manager_aMonitor%_aView_#1) {
+    Manager__stealView(Manager_aMonitor, i)
+    View_arrange(Manager_aMonitor, i)
+    Return
+  }
+
+  aView := Monitor_#%Manager_aMonitor%_aView_#1
+  WinGet, aWndId, ID, A
+  If WinExist("ahk_id" aWndId) And InStr(View_#%Manager_aMonitor%_#%aView%_wndIds, aWndId ";") And Window_isProg(aWndId)
+    View_setActiveWindow(Manager_aMonitor, aView, aWndId)
+
+  Manager_hideShow := True
+  Monitor__hideView(Manager_aMonitor)
+  om := Manager__stealView(Manager_aMonitor, i)
+  if (om > 0) {
+    Monitor__hideView(om)
+    Manager__stealView(om, aView)
+    Monitor__showView(om, aView)
+  }
+  Monitor__showView(Manager_aMonitor, i)
+  Manager_hideShow := False
+
+  wndId := View_getActiveWindow(Manager_aMonitor, i)
+  Manager_winActivate(wndId)
+}
+
 Monitor_activateView(i, d = 0) {
-  Local aView, aWndId, detectHidden, m, n, wndId, wndIds
+  Local aView, aWndId, m, n, wndId
 
   If (i = -1)
     i := Monitor_#%Manager_aMonitor%_aView_#2
@@ -66,36 +147,10 @@ Monitor_activateView(i, d = 0) {
     Else
       m := A_Index
 
-    Monitor_#%m%_aView_#2 := aView
-    Monitor_#%m%_aView_#1 := i
     Manager_hideShow := True
-    SetWinDelay, 0
-    StringTrimRight, wndIds, View_#%m%_#%aView%_wndIds, 1
-    Loop, PARSE, wndIds, `;
-    {
-      If Not (Window_#%A_LoopField%_tags & (1 << i - 1))
-        Window_hide(A_LoopField)
-    }
-    SetWinDelay, 10
-    detectHidden := A_DetectHiddenWindows
-    DetectHiddenWindows, On
-    wndId := View_getActiveWindow(m, i)
-    If wndId
-      Window_set(wndId, "AlwaysOnTop", "On")
-    View_arrange(m, i)
-    DetectHiddenWindows, %detectHidden%
-    StringTrimRight, wndIds, View_#%m%_#%i%_wndIds, 1
-    SetWinDelay, 0
-    Loop, PARSE, wndIds, `;
-    {
-      Window_show(A_LoopField)
-    }
-    Window_set(wndId, "AlwaysOnTop", "Off")
-    SetWinDelay, 10
+    Monitor__hideView(m)
+    Monitor__showView(m, i)
     Manager_hideShow := False
-
-    Bar_updateView(m, aView)
-    Bar_updateView(m, i)
   }
 
   wndId := View_getActiveWindow(Manager_aMonitor, i)


### PR DESCRIPTION
This is a hack to emulate XMonad's greedyView function.

It is similar to Monitor_activateView() but it ensures that there is
only ever one copy of a view (instead of one copy per monitor).  When we
switch to view X using Monitor_greedyView(), all windows from view X on
all monitors are moved to view X on the active monitor.

If the view we're switching to is currently visible on another monitor,
they are swapped.