### PR TITLE
Fix typo in Default_configuration.md

### DIFF
--- a/doc/Default_configuration.md
+++ b/doc/Default_configuration.md
@@ -23,7 +23,7 @@ sub-window of the task bar.
 percentage.
 
 `Config_singleRowBar=1`
-> If false, the bar will have to rows, one for the window title and one for all
+> If false, the bar will have two rows, one for the window title and one for all
 other GUI controls.
 
 `Config_spaciousBar=0`


### PR DESCRIPTION
The word "to" was used where "two" has the intended meaning.