### PR TITLE
Configuration: show where Config.ini is

### DIFF
--- a/doc/Configuring_rules.md
+++ b/doc/Configuring_rules.md
@@ -6,7 +6,7 @@ Not all windows should be managed by bug.n the same way, or even may not be
 managable at all. To handle windows differently, you can add rules to the
 configuration.
 
-The general format of a rule added to `Config.ini` is as follows (all in one
+The general format of a rule added to `%APPDATA%\bugn\Config.ini` is as follows (all in one
 line, ";" is not allowed as a character in the field values):
 
 ```


### PR DESCRIPTION
It is not clearly documented that the program picks up `Config.ini` from the `AppData\Roaming` folder. This documents it for the first time.