### PR TITLE
Fix chrome browser freeze

### DIFF
--- a/src/Window.ahk
+++ b/src/Window.ahk
@@ -18,6 +18,7 @@ Window_activate(wndId) {
     Debug_logMessage("DEBUG[2] Window_activate: Potentially hung window " . wndId, 2)
     Return, 1
   } Else {
+    WinActivate, ahk_class Progman
     WinActivate, ahk_id %wndId%
     WinGet, aWndId, ID, A
     If (wndId != aWndId)


### PR DESCRIPTION
Fixes #279.
Chrome windows were freezing whenever the view they were in was switched to, from a non-empty view It did not happen when switching from an empty view , i.e, with the desktop in focus (ahk_class ProgMan)

So, making every window switch activate progman first, and then the window, thereby simulating the behaviour when switching from a non-empty view, fixes the issue.

This didn't make switching any slower and did not affect any behaviour that is to do with explorer windows (which I looked out for, seeing progman is spawned by explorer.exe). Tested on Windows 10 20H2, OS build 19042.1052
