### PR TITLE
Fix window gap after resolution change

### DIFF
--- a/src/Manager.ahk
+++ b/src/Manager.ahk
@@ -745,6 +745,7 @@ Manager_resetMonitorConfiguration() {
       Debug_logMessage("DEBUG[6] MonitorW: " . Monitor_#%A_Index%_width . ", MMW1: " . mmngr1.monitors[A_Index].width . ", MM1dpiX: " . mmngr1.monitors[A_Index].dpiX . ", MM1scaleX: " . mmngr1.monitors[A_Index].scaleX . ", MMW2: " . mmngr2.monitors[A_Index].width . ", MM2dpiX: " . mmngr2.monitors[A_Index].dpiX . ", MM2scaleX: " . mmngr2.monitors[A_Index].scaleX, 6)
       Bar_init(A_Index)
     }
+    mmngr2 := ""
   }
   Manager_saveState()
   Loop, % Manager_monitorCount {


### PR DESCRIPTION
Clearing mmngr2 at the end of Manager_resetMonitorConfiguration's resolution-change branch re-enables Window_move's DWM invisible-border correction. Without this, every window placement after a monitor resolution change left a ~16px gap until bug.n restarted.